### PR TITLE
fix: default to non-recursive DNS queries to prevent IP bans

### DIFF
--- a/aiodiscover/discovery.py
+++ b/aiodiscover/discovery.py
@@ -7,6 +7,7 @@ from functools import lru_cache, partial
 from itertools import islice
 from typing import TYPE_CHECKING, Any, cast
 
+import pycares
 from aiodns import DNSResolver
 
 from .network import SystemNetworkData
@@ -90,14 +91,27 @@ def chunked(iterable: Iterable[Any], chunked_num: int) -> Iterable[Any]:
 class DiscoverHosts:
     """Discover hosts on the network by ARP and PTR lookup."""
 
-    def __init__(self) -> None:
-        """Init the discovery hosts."""
+    def __init__(self, no_recurse: bool = True) -> None:
+        """
+        Init the discovery hosts.
+
+        Args:
+            no_recurse: If True (default), DNS queries will not request recursion.
+                       This prevents routers from forwarding PTR queries to external
+                       DNS servers, avoiding potential IP bans from public DNS services.
+
+        """
         loop = asyncio.get_running_loop()
         self._loop = loop
         self._sys_network_data: SystemNetworkData | None = None
         self._failed_nameservers: set[IPv4Address | IPv6Address] = set()
         self._last_cache_clear = loop.time()
-        self._resolver = DNSResolver(timeout=DNS_RESPONSE_TIMEOUT)
+
+        # Create resolver with optional no_recurse flag
+        resolver_kwargs = {"timeout": DNS_RESPONSE_TIMEOUT}
+        if no_recurse:
+            resolver_kwargs["flags"] = pycares.ARES_FLAG_NORECURSE
+        self._resolver = DNSResolver(**resolver_kwargs)
 
     def _setup_sys_network_data(self) -> SystemNetworkData:
         ip_route: IPRoute | None = None

--- a/aiodiscover/tests/test_discovery.py
+++ b/aiodiscover/tests/test_discovery.py
@@ -4,9 +4,10 @@ import sys
 from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv4Network
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import aiodns
+import pycares
 import pytest
 
 from aiodiscover import discovery
@@ -380,3 +381,51 @@ async def test_cache_clear() -> None:
         mock_time.return_value = discovery.CACHE_CLEAR_INTERVAL + 10
         discover_hosts._cleanup_cache()
         assert discover_hosts._failed_nameservers == set()
+
+
+@pytest.mark.asyncio
+async def test_no_recurse_default_true() -> None:
+    """Verify that no_recurse defaults to True and sets ARES_FLAG_NORECURSE."""
+    with patch("aiodiscover.discovery.DNSResolver") as mock_resolver_class:
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+
+        # Create DiscoverHosts with default no_recurse=True
+        discovery.DiscoverHosts()
+
+        # Verify DNSResolver was called with flags=ARES_FLAG_NORECURSE
+        mock_resolver_class.assert_called_once_with(
+            timeout=discovery.DNS_RESPONSE_TIMEOUT, flags=pycares.ARES_FLAG_NORECURSE
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_recurse_false() -> None:
+    """Verify that no_recurse=False does not set ARES_FLAG_NORECURSE."""
+    with patch("aiodiscover.discovery.DNSResolver") as mock_resolver_class:
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+
+        # Create DiscoverHosts with no_recurse=False
+        discovery.DiscoverHosts(no_recurse=False)
+
+        # Verify DNSResolver was called without flags
+        mock_resolver_class.assert_called_once_with(
+            timeout=discovery.DNS_RESPONSE_TIMEOUT
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_recurse_true_explicit() -> None:
+    """Verify that explicit no_recurse=True sets ARES_FLAG_NORECURSE."""
+    with patch("aiodiscover.discovery.DNSResolver") as mock_resolver_class:
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+
+        # Create DiscoverHosts with explicit no_recurse=True
+        discovery.DiscoverHosts(no_recurse=True)
+
+        # Verify DNSResolver was called with flags=ARES_FLAG_NORECURSE
+        mock_resolver_class.assert_called_once_with(
+            timeout=discovery.DNS_RESPONSE_TIMEOUT, flags=pycares.ARES_FLAG_NORECURSE
+        )


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/bluetooth-devices/aiodiscover/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

This PR adds support for the `ARES_FLAG_NORECURSE` flag in aiodiscover and enables it by default to prevent DNS recursion during PTR queries.

**Why this change is needed:**
- Home Assistant users are experiencing IP bans from public DNS services (particularly Quad9) due to excessive PTR queries
- These queries occur when routers forward local PTR lookups to external DNS servers
- Quad9 reports receiving ~1 support ticket per week related to Home Assistant's PTR query behavior
- By disabling recursion (not setting the RD bit), PTR queries will only be resolved by the local nameserver

**What this change does:**
- Adds a `no_recurse` parameter to `DiscoverHosts.__init__()` that defaults to `True`
- When enabled, passes `pycares.ARES_FLAG_NORECURSE` to the underlying DNSResolver
- This prevents the DNS queries from requesting recursion from upstream servers

**Backward compatibility:**
- Users who need recursive queries can still set `no_recurse=False` when creating a DiscoverHosts instance
- The default behavior now prevents the problematic recursive queries

Related to home-assistant/core#147152

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/bluetooth-devices/aiodiscover/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->